### PR TITLE
Add create-release.yml

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,7 +1,7 @@
-name: Release created
+name: Create release
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       tag:
         description: 'Git tag value'
@@ -43,11 +43,12 @@ jobs:
 
       - name: Get release version
         id: version
-        run: echo "VALUE=$(npx --yes semver ${{ github.event.release.tag_name }})" >> "$GITHUB_OUTPUT"
+        run: echo "VALUE=$(npx --yes semver ${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
 
       - name: Update project version
         run: |
           poetry version ${{ steps.version.outputs.VALUE }}
           git add pyproject.toml
           git commit -m "chore: release ${{ steps.version.outputs.VALUE }}"
-          git push
+          git tag ${{ steps.version.outputs.VALUE }}
+          git push origin ${{ steps.version.outputs.VALUE }}

--- a/.github/workflows/release-created.yml
+++ b/.github/workflows/release-created.yml
@@ -1,9 +1,12 @@
 name: Release created
 
 on:
-  release:
-    types:
-      - created
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Git tag value'
+        required: true
+        type: string
 
 env:
   PYTHON_VERSION: "3.11"


### PR DESCRIPTION
This workflow is intended to be called via the GitHub Actions UI when performing a new release. It accepts one input, the git `tag` value, and this value is then added to the `pyproject.toml` and `package.json` files with a commit. A new git tag based on the input value is also created.

At this point, there is a new git tag on the GitHub repo. The maintainer is then expected to create a new release based on this tag via GitHub Releases.